### PR TITLE
Stop manually tracking LAST_UPDATED (close #11)

### DIFF
--- a/git-sleep.gemspec
+++ b/git-sleep.gemspec
@@ -3,7 +3,6 @@ require File.expand_path('../lib/git_sleep', __FILE__)
 Gem::Specification.new do |git_sleep|
   git_sleep.name = 'git-sleep'
   git_sleep.version = GitSleep::VERSION
-  git_sleep.date = GitSleep::LAST_UPDATED
   git_sleep.summary = 'Uses Jawbone to figure out if you are awake enough' \
     'to code based on your sleep data'
   git_sleep.description   = 'Uses Jawbone to figure out if you are awake ' \

--- a/lib/git_sleep.rb
+++ b/lib/git_sleep.rb
@@ -1,6 +1,5 @@
 module GitSleep
   VERSION      = '0.1.1'
-  LAST_UPDATED = '2013-08-20'
   NETRC_PATH   = File.expand_path('~/.netrc')
   OUR_SITE     = 'http://www.gitsleep.com'
 end


### PR DESCRIPTION
we have git for that, and `date` is not a required field for the gemspec
