### PR TITLE
lock dependencies better (closes #15)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     git-sleep (0.1.1)
-      httparty
-      netrc
+      httparty (~> 0.13)
+      netrc (~> 0.8)
 
 GEM
   remote: https://rubygems.org/
@@ -57,4 +57,4 @@ DEPENDENCIES
   git-sleep!
   pry (~> 0.10)
   rspec (~> 3.1)
-  rubocop (~> 0.27.1)
+  rubocop (~> 0.27)

--- a/git-sleep.gemspec
+++ b/git-sleep.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |git_sleep|
   git_sleep.homepage      = GitSleep::OUR_SITE
   git_sleep.license       = 'MIT'
   git_sleep.required_ruby_version = '>= 1.8.7'
-  git_sleep.add_runtime_dependency 'httparty'
-  git_sleep.add_runtime_dependency 'netrc'
-  git_sleep.add_development_dependency 'rubocop', '~> 0.27.1'
+  git_sleep.add_runtime_dependency 'httparty', '~> 0.13'
+  git_sleep.add_runtime_dependency 'netrc', '~> 0.8'
+  git_sleep.add_development_dependency 'rubocop', '~> 0.27'
   git_sleep.add_development_dependency 'rspec', '~> 3.1'
   git_sleep.add_development_dependency 'pry', '~> 0.10'
 end


### PR DESCRIPTION
- we should specify a version
- but we don't need to specify the exact version
